### PR TITLE
Improve integration tests with zip support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ erased-serde = "0.4.6"
 [dev-dependencies]
 quick-xml = "0.38.0"
 tempfile = "3.20.0"
+assert_cmd = "2.0.17"
 
 # Profile configuration to optimize dependencies even in debug builds
 [profile.dev]


### PR DESCRIPTION
## Summary
- add `assert_cmd` as a dev dependency
- rewrite integration test to use `assert_cmd` and temporary files
- add test verifying zip input behaves the same as XML

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68634f2bc3c0832fad8592ecaf1c2e4c