### PR TITLE
Add project docs and update agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,4 @@ Codex must follow these guidelines when editing this repository:
 - Run the full test suite with `cargo test` and include the results in the PR description.
 - Run `cargo check` and make sure the warnings and errors are resolved
 - Don't leave any unused code
+- When modifying the file structure or architecture, evaluate whether `README.md` or `docs/PROJECT_STRUCTURE.md` need updates and revise them if required.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ To process an Apple Health export and generate a ZIP file with CSV outputs:
 gpt-os -v export.zip my_health_data.zip
 ```
 
+## Project Structure
+
+The repository contains the Rust source code under `src/`, tests in `tests/`, and
+additional documentation in `docs/`. Key modules include `core.rs` for the
+transformation engine, `apple_health/` for domain-specific extractors and data
+types, and `sinks/` for output implementations. A full breakdown of files and
+their roles is available in [docs/PROJECT_STRUCTURE.md](docs/PROJECT_STRUCTURE.md).
+
 ## Testing
 
 Integration tests are included in the `tests` directory. You can run the tests using:

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -1,0 +1,46 @@
+# Project Structure
+
+This document provides an overview of the repository layout and explains the purpose of the major directories and files.
+
+```text
+.
+├── src/                # Application and library code
+│   ├── main.rs         # Command-line entry point
+│   ├── lib.rs          # Library module declarations
+│   ├── config.rs       # CLI configuration and argument parsing
+│   ├── core.rs         # Core traits and the transformation engine
+│   ├── error.rs        # Centralized error definitions
+│   ├── xml_utils.rs    # Helpers for streaming XML processing
+│   ├── apple_health/   # Apple Health specific implementation
+│   │   ├── extractor.rs  # Extractor reading Apple Health exports
+│   │   ├── types.rs      # Data models representing XML records
+│   │   └── mod.rs        # Module declarations
+│   └── sinks/          # Output sinks for processed data
+│       ├── csv_zip.rs    # Sink writing grouped records to zipped CSV
+│       └── mod.rs
+├── tests/              # Unit and integration tests
+│   ├── fixtures/       # Sample XML exports used by tests
+│   ├── integration_tests.rs
+│   └── unit.rs
+├── Cargo.toml          # Package configuration
+├── README.md           # Project overview and usage instructions
+├── AGENTS.md           # Coding and contribution guidelines for Codex
+└── docs/               # Additional documentation (this folder)
+    └── PROJECT_STRUCTURE.md (this file)
+```
+
+## Architectural Overview
+
+The project is built around a generic transformation engine defined in `src/core.rs`. The engine orchestrates the extraction of `Processable` records from an input source and loads the grouped records into a configurable sink. The first implementation focuses on Apple Health data:
+
+- **Extractor**: `apple_health::extractor::AppleHealthExtractor` reads zipped or plain XML exports and streams `GenericRecord` values.
+- **Processable types**: Defined in `apple_health::types`, these models represent the XML elements found in the export.
+- **Sink**: `sinks::csv_zip::CsvZipSink` groups the records and writes them to compressed CSV files inside a ZIP archive.
+
+The command-line interface in `src/main.rs` wires these pieces together using `Config` from `src/config.rs`. Logging and error handling are provided by `env_logger` and the custom `error` module.
+
+```
+Flow: Extractor -> Engine -> Sink
+```
+
+Future transformers or sinks can implement the `Extractor` and `Sink` traits to extend the tool for new data sources or output formats.


### PR DESCRIPTION
## Summary
- document architecture and folder layout in `docs/PROJECT_STRUCTURE.md`
- link the new documentation from README
- update `AGENTS.md` so Codex checks whether docs need updating when structure changes

## Testing
- `cargo fmt`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68646530e828832fadc13538a541eeb0