### PR TITLE
Optimize transformation worker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 [dependencies]
 quick-xml = "0.38.0"
 rayon = "1.6"
-dashmap = "6.1.0"
 csv = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,8 +1,8 @@
 use crate::error::Result;
 use crossbeam_channel as channel;
-use dashmap::DashMap;
 use erased_serde::Serialize;
 use log::{debug, info};
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::path::Path;
 use std::time::Instant;
@@ -28,7 +28,7 @@ pub trait Extractor<T: Processable> {
 
 /// Loads grouped records into a data sink.
 pub trait Sink<T: Processable> {
-    fn load(&self, grouped_records: DashMap<String, Vec<T>>, output_path: &Path) -> Result<()>;
+    fn load(&self, grouped_records: HashMap<String, Vec<T>>, output_path: &Path) -> Result<()>;
 }
 
 pub struct Engine<T, E, S>
@@ -81,13 +81,10 @@ where
             "Starting transformation phase with {} workers...",
             self.num_workers
         );
-        let grouped_records = transformer::transform(receiver, self.num_workers);
+        let grouped_records = transformer::transform(receiver);
         let transform_duration = transform_start.elapsed();
 
-        let total_records: usize = grouped_records
-            .iter()
-            .map(|entry| entry.value().len())
-            .sum();
+        let total_records: usize = grouped_records.iter().map(|(_, v)| v.len()).sum();
         let record_types = grouped_records.len();
         info!(
             "Transformation completed in {:.3}s: {} records grouped into {} types",
@@ -130,59 +127,36 @@ where
 mod transformer {
     use super::Processable;
     use crossbeam_channel::Receiver;
-    use dashmap::DashMap;
     use log::{debug, info};
-    use std::sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    };
-    use std::thread;
+    use rayon::iter::{ParallelBridge, ParallelIterator};
+    use std::collections::HashMap;
     use std::time::Instant;
 
-    pub fn transform<T: Processable>(
-        receiver: Receiver<T>,
-        num_workers: usize,
-    ) -> DashMap<String, Vec<T>> {
+    pub fn transform<T: Processable>(receiver: Receiver<T>) -> HashMap<String, Vec<T>> {
         let start_time = Instant::now();
-        let grouped_records: Arc<DashMap<String, Vec<T>>> = Arc::new(DashMap::new());
-        let records_processed = Arc::new(AtomicUsize::new(0));
-        let mut handles = Vec::with_capacity(num_workers);
-
-        debug!("Spawning {} worker threads for transformation", num_workers);
-
-        for i in 0..num_workers {
-            let rx = receiver.clone();
-            let grouped_records = Arc::clone(&grouped_records);
-            let records_processed = Arc::clone(&records_processed);
-            handles.push(thread::spawn(move || {
-                let mut local_count = 0;
-                for record in rx.iter() {
-                    grouped_records
-                        .entry(record.grouping_key())
-                        .or_default()
-                        .push(record);
-                    local_count += 1;
-
-                    if local_count % 1000 == 0 {
-                        debug!("Worker {} processed {} records", i, local_count);
+        let (grouped_records, total_processed) = receiver
+            .into_iter()
+            .par_bridge()
+            .fold(
+                || (HashMap::<String, Vec<T>>::new(), 0usize),
+                |(mut map, count), record| {
+                    map.entry(record.grouping_key()).or_default().push(record);
+                    (map, count + 1)
+                },
+            )
+            .reduce(
+                || (HashMap::<String, Vec<T>>::new(), 0),
+                |(mut a, acount), (b, bcount)| {
+                    for (k, mut v) in b {
+                        a.entry(k).or_default().extend(v.drain(..));
                     }
-                }
-                records_processed.fetch_add(local_count, Ordering::Relaxed);
-                debug!("Worker {} finished processing {} records", i, local_count);
-            }));
-        }
+                    (a, acount + bcount)
+                },
+            );
 
-        for (i, handle) in handles.into_iter().enumerate() {
-            match handle.join() {
-                Ok(()) => debug!("Worker {} completed successfully", i),
-                Err(_) => panic!("Worker {} panicked", i),
-            }
-        }
-
-        let total_processed = records_processed.load(Ordering::Relaxed);
         let duration = start_time.elapsed();
         info!(
-            "Transformation workers completed: {} records processed in {:.3}s",
+            "Transformation completed: {} records processed in {:.3}s",
             total_processed,
             duration.as_secs_f64()
         );
@@ -195,6 +169,6 @@ mod transformer {
             );
         }
 
-        Arc::try_unwrap(grouped_records).unwrap()
+        grouped_records
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod xml_utils;
 
 use clap::Parser;
 use log::{LevelFilter, error, info};
+use rayon::ThreadPoolBuilder;
 use std::path::Path;
 use std::process;
 
@@ -33,6 +34,11 @@ fn main() {
     let num_workers = config
         .threads
         .unwrap_or_else(|| std::thread::available_parallelism().map_or(1, |p| p.get()));
+
+    ThreadPoolBuilder::new()
+        .num_threads(num_workers)
+        .build_global()
+        .expect("Failed to initialize global thread pool");
 
     let engine = core::Engine::new(extractor, sink, num_workers);
 

--- a/src/sinks/csv_zip.rs
+++ b/src/sinks/csv_zip.rs
@@ -1,8 +1,8 @@
 use crate::core::{Processable, Sink};
 use crate::error::Result;
-use dashmap::DashMap;
 use log::{debug, info, warn};
 use rayon::prelude::*;
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Cursor, Write};
 use std::path::Path;
@@ -16,7 +16,7 @@ impl<T> Sink<T> for CsvZipSink
 where
     T: Processable + Send + Sync + 'static,
 {
-    fn load(&self, grouped_records: DashMap<String, Vec<T>>, output_path: &Path) -> Result<()> {
+    fn load(&self, grouped_records: HashMap<String, Vec<T>>, output_path: &Path) -> Result<()> {
         let start = Instant::now();
 
         // 1. Drain and filter empty groups into a Vec

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -1,10 +1,10 @@
-use dashmap::DashMap;
 use gpt_os::apple_health::types::GenericRecord;
 use gpt_os::core::{Processable, Sink};
 use gpt_os::sinks::csv_zip::CsvZipSink;
 use gpt_os::xml_utils;
 use quick_xml::Reader;
 use quick_xml::events::Event;
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 use tempfile::NamedTempFile;
@@ -161,7 +161,7 @@ fn csv_sink_sorts_records_by_date() {
     let r1 = parse(xml1);
     let r2 = parse(xml2);
 
-    let map: DashMap<String, Vec<GenericRecord>> = DashMap::new();
+    let mut map: HashMap<String, Vec<GenericRecord>> = HashMap::new();
     map.entry("Steps".to_string()).or_default().extend([r1, r2]);
 
     let tmp = NamedTempFile::new().unwrap();


### PR DESCRIPTION
## Summary
- refactor transformer to use rayon parallelism
- drop DashMap usage and fold records into a HashMap
- update Sink trait and CsvZipSink to accept HashMap
- adjust unit tests accordingly
- use global rayon thread pool and tidy imports

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68671293323c832f9fefdfee069e20e6