### PR TITLE
Flatten CSV columns

### DIFF
--- a/src/apple_health/types.rs
+++ b/src/apple_health/types.rs
@@ -39,12 +39,12 @@ impl Serialize for GenericRecord {
     where
         S: Serializer,
     {
-        use serde::ser::SerializeStruct;
-        let mut state = serializer.serialize_struct("GenericRecord", 2)?;
-        state.serialize_field("element", &self.element_name)?;
-        let attrs = serde_json::to_string(&self.attributes).map_err(serde::ser::Error::custom)?;
-        state.serialize_field("attributes", &attrs)?;
-        state.end()
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(Some(self.attributes.len()))?;
+        for (k, v) in &self.attributes {
+            map.serialize_entry(k, v)?;
+        }
+        map.end()
     }
 }
 


### PR DESCRIPTION
## Summary
- flatten attributes for `GenericRecord` serialization
- write CSV headers from attribute keys and rows from per-record values
- restore `Processable::as_serializable` with `erased-serde` dependency
- document usage of `as_serializable` in CSV sink

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68728f8cc8f0832fa23e36006fe67166