### PR TITLE
Use per-phase thread pool counts from CLI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -73,4 +73,3 @@ Target: 700k+ records/second. Use `--no-metrics` to disable throughput logging d
 - Update `README.md` and `docs/PROJECT_STRUCTURE.md` when changing architecture
 - Performance optimizations in `Cargo.toml`: dependencies built with `opt-level = 3` even in debug
 - Generic design supports future data sources beyond Apple Health
-- Threading is configurable via CLI `--threads` option

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 [dependencies]
 quick-xml = "0.38.0"
 rayon = "1.6"
-dashmap = "6.1.0"
 csv = "1.1"
 zip = "4.2.0"
 crossbeam-channel = "0.5"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Written in Rust, the project aims to provide a framework for transforming variou
 
 - Multithreaded XML parsing using `quick-xml` and `Rayon` for optimal performance.
 - Memory-efficient processing with streaming and chunked buffering.
+- Dedicated Rayon thread pools for transform and load phases to avoid contention.
 - Outputs structured CSV files for various health record types, all compressed into a single ZIP archive.
 - Robust error handling and logging capabilities.
 - Cross-platform compatibility (Linux, macOS, Windows).
@@ -36,7 +37,9 @@ gpt-os [OPTIONS] <INPUT_FILE> <OUTPUT_ZIP>
 ### Options
 
 - `-v, --verbose`: Enable verbose logging.
-- `-t, --threads <N>`: Limit the number of worker threads (default is all available CPU cores).
+- `--extract-threads <N>`: Threads for extraction phase (default: available/2 + 1).
+- `--transform-threads <N>`: Threads for transformation phase (default: available/2 + 1).
+- `--load-threads <N>`: Threads for load phase (default: available/2 + 1).
 - `--no-metrics`: Disable printing of end-of-run metrics.
 - `-h, --help`: Show usage information.
 

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -39,6 +39,8 @@ The project is built around a generic transformation engine defined in `src/core
 
 The command-line interface in `src/main.rs` wires these pieces together using `Config` from `src/config.rs`. Logging and error handling are provided by `env_logger` and the custom `error` module.
 
+Parallelism is handled using dedicated Rayon thread pools for each phase of the ETL pipeline. The number of threads for extraction, transformation and loading can be configured via CLI options, with sensible defaults based on the available hardware.
+
 ```
 Flow: Extractor -> Engine -> Sink
 ```

--- a/src/apple_health/extractor.rs
+++ b/src/apple_health/extractor.rs
@@ -5,35 +5,44 @@ use crate::apple_health::types::GenericRecord;
 use crate::core::Extractor;
 use crate::error::Result;
 use crossbeam_channel as channel;
+use rayon::ThreadPoolBuilder;
 use std::{path::Path, sync::Arc, thread};
 
 pub struct AppleHealthExtractor;
 
 impl Extractor<GenericRecord> for AppleHealthExtractor {
-    fn extract(&self, input_path: &Path) -> Result<channel::Receiver<GenericRecord>> {
+    fn extract(
+        &self,
+        input_path: &Path,
+        threads: usize,
+    ) -> Result<channel::Receiver<GenericRecord>> {
         let (sender, receiver) = channel::unbounded();
         let input_path = input_path.to_owned();
 
         thread::spawn(move || {
-            let result: Result<()> = (|| {
+            let pool = ThreadPoolBuilder::new()
+                .num_threads(threads)
+                .build()
+                .expect("create thread pool");
+            let result: Result<()> = pool.install(|| {
                 if input_path.extension().and_then(|s| s.to_str()) == Some("zip") {
-                    // For ZIP files, we still need to extract to memory first
                     let content = xml_utils::extract_xml_from_zip(&input_path)?;
                     xml_utils::process_memory_chunks(
                         &content,
-                        sender,
+                        &sender,
                         Arc::new(Self::parse_generic),
                     )?;
                 } else {
-                    // For regular XML files, use memory-mapped processing
                     xml_utils::process_xml_file_mmap(
                         &input_path,
-                        sender,
+                        &sender,
                         Arc::new(Self::parse_generic),
                     )?;
                 }
                 Ok(())
-            })();
+            });
+
+            drop(sender);
 
             if let Err(_) = result {
                 // Error occurred, but we can't send it through the channel

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,9 +15,17 @@ pub struct Config {
     #[arg(short, long)]
     pub verbose: bool,
 
-    /// Limit the number of worker threads
-    #[arg(short, long)]
-    pub threads: Option<usize>,
+    /// Number of threads for the extraction phase
+    #[arg(long)]
+    pub extract_threads: Option<usize>,
+
+    /// Number of threads for the transformation phase
+    #[arg(long)]
+    pub transform_threads: Option<usize>,
+
+    /// Number of threads for the load phase
+    #[arg(long)]
+    pub load_threads: Option<usize>,
 
     /// Disable printing of end-of-run metrics
     #[arg(long)]

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,7 +1,8 @@
 use crate::error::Result;
 use crossbeam_channel as channel;
-use dashmap::DashMap;
 use log::{debug, info};
+use rayon::ThreadPoolBuilder;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::path::Path;
 use std::time::Instant;
@@ -19,12 +20,17 @@ pub trait Processable: Send + Sync + Debug + 'static {
 
 /// Extracts records from a data source into a channel.
 pub trait Extractor<T: Processable> {
-    fn extract(&self, input_path: &Path) -> Result<channel::Receiver<T>>;
+    fn extract(&self, input_path: &Path, threads: usize) -> Result<channel::Receiver<T>>;
 }
 
 /// Loads grouped records into a data sink.
 pub trait Sink<T: Processable> {
-    fn load(&self, grouped_records: DashMap<String, Vec<T>>, output_path: &Path) -> Result<()>;
+    fn load(
+        &self,
+        grouped_records: HashMap<String, Vec<T>>,
+        output_path: &Path,
+        threads: usize,
+    ) -> Result<()>;
 }
 
 pub struct Engine<T, E, S>
@@ -35,7 +41,6 @@ where
 {
     extractor: E,
     sink: S,
-    num_workers: usize,
     _marker: std::marker::PhantomData<T>,
 }
 
@@ -45,26 +50,38 @@ where
     E: Extractor<T>,
     S: Sink<T>,
 {
-    pub fn new(extractor: E, sink: S, num_workers: usize) -> Self {
+    pub fn new(extractor: E, sink: S) -> Self {
         Self {
             extractor,
             sink,
-            num_workers,
             _marker: std::marker::PhantomData,
         }
     }
 
-    pub fn run(&self, input_path: &Path, output_path: &Path) -> Result<()> {
+    pub fn run(
+        &self,
+        input_path: &Path,
+        output_path: &Path,
+        extract_threads: usize,
+        transform_threads: usize,
+        load_threads: usize,
+    ) -> Result<()> {
         let start_time = Instant::now();
         info!("Starting ETL pipeline");
         info!("Input: {}", input_path.display());
         info!("Output: {}", output_path.display());
-        info!("Workers: {}", self.num_workers);
+        info!(
+            "Threads - extract: {}, transform: {}, load: {}",
+            extract_threads, transform_threads, load_threads
+        );
 
         // Extract phase
         let extract_start = Instant::now();
-        info!("Starting extraction phase...");
-        let receiver = self.extractor.extract(input_path)?;
+        info!(
+            "Starting extraction phase with {} workers...",
+            extract_threads
+        );
+        let receiver = self.extractor.extract(input_path, extract_threads)?;
         let extract_duration = extract_start.elapsed();
         debug!(
             "Extraction phase setup completed in {:.3}s",
@@ -75,15 +92,16 @@ where
         let transform_start = Instant::now();
         info!(
             "Starting transformation phase with {} workers...",
-            self.num_workers
+            transform_threads
         );
-        let grouped_records = transformer::transform(receiver, self.num_workers);
+        let pool = ThreadPoolBuilder::new()
+            .num_threads(transform_threads)
+            .build()
+            .expect("create thread pool");
+        let grouped_records = pool.install(|| transformer::transform(receiver));
         let transform_duration = transform_start.elapsed();
 
-        let total_records: usize = grouped_records
-            .iter()
-            .map(|entry| entry.value().len())
-            .sum();
+        let total_records: usize = grouped_records.iter().map(|(_, v)| v.len()).sum();
         let record_types = grouped_records.len();
         info!(
             "Transformation completed in {:.3}s: {} records grouped into {} types",
@@ -94,8 +112,8 @@ where
 
         // Load phase
         let load_start = Instant::now();
-        info!("Starting load phase...");
-        self.sink.load(grouped_records, output_path)?;
+        info!("Starting load phase with {} workers...", load_threads);
+        self.sink.load(grouped_records, output_path, load_threads)?;
         let load_duration = load_start.elapsed();
         info!(
             "Load phase completed in {:.3}s",
@@ -126,59 +144,36 @@ where
 mod transformer {
     use super::Processable;
     use crossbeam_channel::Receiver;
-    use dashmap::DashMap;
     use log::{debug, info};
-    use std::sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    };
-    use std::thread;
+    use rayon::iter::{ParallelBridge, ParallelIterator};
+    use std::collections::HashMap;
     use std::time::Instant;
 
-    pub fn transform<T: Processable>(
-        receiver: Receiver<T>,
-        num_workers: usize,
-    ) -> DashMap<String, Vec<T>> {
+    pub fn transform<T: Processable>(receiver: Receiver<T>) -> HashMap<String, Vec<T>> {
         let start_time = Instant::now();
-        let grouped_records: Arc<DashMap<String, Vec<T>>> = Arc::new(DashMap::new());
-        let records_processed = Arc::new(AtomicUsize::new(0));
-        let mut handles = Vec::with_capacity(num_workers);
-
-        debug!("Spawning {} worker threads for transformation", num_workers);
-
-        for i in 0..num_workers {
-            let rx = receiver.clone();
-            let grouped_records = Arc::clone(&grouped_records);
-            let records_processed = Arc::clone(&records_processed);
-            handles.push(thread::spawn(move || {
-                let mut local_count = 0;
-                for record in rx.iter() {
-                    grouped_records
-                        .entry(record.grouping_key())
-                        .or_default()
-                        .push(record);
-                    local_count += 1;
-
-                    if local_count % 1000 == 0 {
-                        debug!("Worker {} processed {} records", i, local_count);
+        let (grouped_records, total_processed) = receiver
+            .into_iter()
+            .par_bridge()
+            .fold(
+                || (HashMap::<String, Vec<T>>::new(), 0usize),
+                |(mut map, count), record| {
+                    map.entry(record.grouping_key()).or_default().push(record);
+                    (map, count + 1)
+                },
+            )
+            .reduce(
+                || (HashMap::<String, Vec<T>>::new(), 0),
+                |(mut a, acount), (b, bcount)| {
+                    for (k, mut v) in b {
+                        a.entry(k).or_default().extend(v.drain(..));
                     }
-                }
-                records_processed.fetch_add(local_count, Ordering::Relaxed);
-                debug!("Worker {} finished processing {} records", i, local_count);
-            }));
-        }
+                    (a, acount + bcount)
+                },
+            );
 
-        for (i, handle) in handles.into_iter().enumerate() {
-            match handle.join() {
-                Ok(()) => debug!("Worker {} completed successfully", i),
-                Err(_) => panic!("Worker {} panicked", i),
-            }
-        }
-
-        let total_processed = records_processed.load(Ordering::Relaxed);
         let duration = start_time.elapsed();
         info!(
-            "Transformation workers completed: {} records processed in {:.3}s",
+            "Transformation completed: {} records processed in {:.3}s",
             total_processed,
             duration.as_secs_f64()
         );
@@ -191,6 +186,6 @@ mod transformer {
             );
         }
 
-        Arc::try_unwrap(grouped_records).unwrap()
+        grouped_records
     }
 }

--- a/src/xml_utils.rs
+++ b/src/xml_utils.rs
@@ -121,7 +121,7 @@ where
 /// Process XML file using memory-mapped I/O
 pub fn process_xml_file_mmap<T>(
     input_path: &Path,
-    sender: channel::Sender<T>,
+    sender: &channel::Sender<T>,
     parse_fn: Arc<dyn Fn(&BytesStart) -> Option<T> + Send + Sync + 'static>,
 ) -> Result<()>
 where
@@ -129,7 +129,7 @@ where
 {
     let file = File::open(input_path)?;
     let mmap = unsafe { Mmap::map(&file)? };
-    let processed = process_chunks(&mmap[..], &sender, parse_fn);
+    let processed = process_chunks(&mmap[..], sender, parse_fn);
     log::info!("Mmap chunks processed: {}", processed);
     Ok(())
 }
@@ -137,13 +137,13 @@ where
 /// Process chunks from memory (for ZIP files)
 pub fn process_memory_chunks<T>(
     content: &[u8],
-    sender: channel::Sender<T>,
+    sender: &channel::Sender<T>,
     parse_fn: Arc<dyn Fn(&BytesStart) -> Option<T> + Send + Sync + 'static>,
 ) -> Result<()>
 where
     T: Send + 'static,
 {
-    let processed = process_chunks(content, &sender, parse_fn);
+    let processed = process_chunks(content, sender, parse_fn);
     log::info!("Memory chunks processed: {}", processed);
     Ok(())
 }

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -1,10 +1,10 @@
-use dashmap::DashMap;
 use gpt_os::apple_health::types::GenericRecord;
 use gpt_os::core::{Processable, Sink};
 use gpt_os::sinks::csv_zip::CsvZipSink;
 use gpt_os::xml_utils;
 use quick_xml::Reader;
 use quick_xml::events::Event;
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 use tempfile::NamedTempFile;
@@ -161,11 +161,11 @@ fn csv_sink_sorts_records_by_date() {
     let r1 = parse(xml1);
     let r2 = parse(xml2);
 
-    let map: DashMap<String, Vec<GenericRecord>> = DashMap::new();
+    let mut map: HashMap<String, Vec<GenericRecord>> = HashMap::new();
     map.entry("Steps".to_string()).or_default().extend([r1, r2]);
 
     let tmp = NamedTempFile::new().unwrap();
-    CsvZipSink.load(map, tmp.path()).unwrap();
+    CsvZipSink.load(map, tmp.path(), 1).unwrap();
 
     let file = File::open(tmp.path()).unwrap();
     let mut archive = ZipArchive::new(file).unwrap();


### PR DESCRIPTION
## Summary
- allow configuring threads for extraction, transform, and load phases
- wire thread counts through engine and sink
- update docs with new CLI options

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6872aa69c5ac832fa3a8355526b1b47e