### PR TITLE
Preload ETL thread pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Written in Rust, the project aims to provide a framework for transforming variou
 
 - Multithreaded XML parsing using `quick-xml` and `Rayon` for optimal performance.
 - Memory-efficient processing with streaming and chunked buffering.
-- Dedicated Rayon thread pools for transform and load phases to avoid contention.
+- Dedicated Rayon thread pools for each phase are preloaded at startup to avoid latency.
 - Outputs structured CSV files for various health record types, all compressed into a single ZIP archive.
 - Robust error handling and logging capabilities.
 - Cross-platform compatibility (Linux, macOS, Windows).

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -39,7 +39,7 @@ The project is built around a generic transformation engine defined in `src/core
 
 The command-line interface in `src/main.rs` wires these pieces together using `Config` from `src/config.rs`. Logging and error handling are provided by `env_logger` and the custom `error` module.
 
-Parallelism is handled using dedicated Rayon thread pools for each phase of the ETL pipeline. The number of threads for extraction, transformation and loading can be configured via CLI options, with sensible defaults based on the available hardware.
+Parallelism is handled using dedicated Rayon thread pools for each phase of the ETL pipeline. These pools are preloaded before processing begins. The number of threads for extraction, transformation and loading can be configured via CLI options, with sensible defaults based on the available hardware.
 
 ```
 Flow: Extractor -> Engine -> Sink

--- a/src/apple_health/extractor.rs
+++ b/src/apple_health/extractor.rs
@@ -5,7 +5,7 @@ use crate::apple_health::types::GenericRecord;
 use crate::core::Extractor;
 use crate::error::Result;
 use crossbeam_channel as channel;
-use rayon::ThreadPoolBuilder;
+use rayon::ThreadPool;
 use std::{path::Path, sync::Arc, thread};
 
 pub struct AppleHealthExtractor;
@@ -14,16 +14,12 @@ impl Extractor<GenericRecord> for AppleHealthExtractor {
     fn extract(
         &self,
         input_path: &Path,
-        threads: usize,
+        pool: Arc<ThreadPool>,
     ) -> Result<channel::Receiver<GenericRecord>> {
         let (sender, receiver) = channel::unbounded();
         let input_path = input_path.to_owned();
 
         thread::spawn(move || {
-            let pool = ThreadPoolBuilder::new()
-                .num_threads(threads)
-                .build()
-                .expect("create thread pool");
             let result: Result<()> = pool.install(|| {
                 if input_path.extension().and_then(|s| s.to_str()) == Some("zip") {
                     let content = xml_utils::extract_xml_from_zip(&input_path)?;

--- a/src/sinks/csv_zip.rs
+++ b/src/sinks/csv_zip.rs
@@ -1,7 +1,7 @@
 use crate::core::{Processable, Sink};
 use crate::error::Result;
 use log::{debug, info, warn};
-use rayon::{ThreadPoolBuilder, prelude::*};
+use rayon::prelude::*;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Cursor, Write};
@@ -25,12 +25,7 @@ impl<T> Sink<T> for CsvZipSink
 where
     T: Processable + CsvWritable + Send + Sync + 'static,
 {
-    fn load(
-        &self,
-        grouped_records: HashMap<String, Vec<T>>,
-        output_path: &Path,
-        threads: usize,
-    ) -> Result<()> {
+    fn load(&self, grouped_records: HashMap<String, Vec<T>>, output_path: &Path) -> Result<()> {
         let start = Instant::now();
 
         // 1. Drain and filter empty groups into a Vec
@@ -55,49 +50,46 @@ where
         );
 
         // 2. Parallel CSV serialization into byte buffers using a dedicated thread pool
-        let pool = ThreadPoolBuilder::new().num_threads(threads).build()?;
-        let mini_zips: Vec<_> = pool.install(|| {
-            entries
-                .into_par_iter()
-                .map(|(name, mut recs)| -> Result<_> {
-                    use std::collections::BTreeSet;
-                    recs.sort_by_key(|r| r.sort_key().unwrap_or_default());
-                    // a) build CSV in memory
-                    let mut buf = Vec::with_capacity(recs.len() * 100);
-                    {
-                        let mut header_set = BTreeSet::new();
-                        for r in &recs {
-                            header_set.extend(r.headers());
-                        }
-                        let headers: Vec<String> = header_set.into_iter().collect();
-
-                        let mut w = csv::WriterBuilder::new()
-                            .has_headers(true)
-                            .from_writer(&mut buf);
-                        w.write_record(&headers)?;
-                        for r in &recs {
-                            r.write(&mut w, &headers)?;
-                        }
-                        w.flush()?;
+        let mini_zips: Vec<_> = entries
+            .into_par_iter()
+            .map(|(name, mut recs)| -> Result<_> {
+                use std::collections::BTreeSet;
+                recs.sort_by_key(|r| r.sort_key().unwrap_or_default());
+                // a) build CSV in memory
+                let mut buf = Vec::with_capacity(recs.len() * 100);
+                {
+                    let mut header_set = BTreeSet::new();
+                    for r in &recs {
+                        header_set.extend(r.headers());
                     }
-                    debug!("CSV for '{}' is {} bytes", name, buf.len());
+                    let headers: Vec<String> = header_set.into_iter().collect();
 
-                    // b) wrap in a 1-entry ZIP
-                    let mut cursor = Cursor::new(Vec::with_capacity(buf.len() / 3));
-                    {
-                        let mut mini = ZipWriter::new(&mut cursor);
-                        let opts = FileOptions::<()>::default()
-                            .compression_method(CompressionMethod::Deflated)
-                            .unix_permissions(0o644);
-                        mini.start_file(format!("{}.csv", &name), opts)?;
-                        mini.write_all(&buf)?;
-                        mini.finish()?;
+                    let mut w = csv::WriterBuilder::new()
+                        .has_headers(true)
+                        .from_writer(&mut buf);
+                    w.write_record(&headers)?;
+                    for r in &recs {
+                        r.write(&mut w, &headers)?;
                     }
-                    cursor.set_position(0);
-                    Ok((name, cursor))
-                })
-                .collect::<Result<_>>()
-        })?;
+                    w.flush()?;
+                }
+                debug!("CSV for '{}' is {} bytes", name, buf.len());
+
+                // b) wrap in a 1-entry ZIP
+                let mut cursor = Cursor::new(Vec::with_capacity(buf.len() / 3));
+                {
+                    let mut mini = ZipWriter::new(&mut cursor);
+                    let opts = FileOptions::<()>::default()
+                        .compression_method(CompressionMethod::Deflated)
+                        .unix_permissions(0o644);
+                    mini.start_file(format!("{}.csv", &name), opts)?;
+                    mini.write_all(&buf)?;
+                    mini.finish()?;
+                }
+                cursor.set_position(0);
+                Ok((name, cursor))
+            })
+            .collect::<Result<_>>()?;
 
         // 3. Merge them into the final ZIP
         let mut out = File::create(output_path)?;

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -165,7 +165,11 @@ fn csv_sink_sorts_records_by_date() {
     map.entry("Steps".to_string()).or_default().extend([r1, r2]);
 
     let tmp = NamedTempFile::new().unwrap();
-    CsvZipSink.load(map, tmp.path(), 1).unwrap();
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(1)
+        .build()
+        .unwrap();
+    pool.install(|| CsvZipSink.load(map, tmp.path())).unwrap();
 
     let file = File::open(tmp.path()).unwrap();
     let mut archive = ZipArchive::new(file).unwrap();


### PR DESCRIPTION
## Summary
- preload thread pools for extract, transform and load phases
- adjust trait signatures to pass prebuilt pools
- update README and docs about preloaded pools
- adapt unit tests
- switch load phase to run within `load_pool.install`

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6872dba98e98832faed0943dd0131057