### PR TITLE
Add Criterion flamegraph benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tempfile = "3.20.0"
 quick-xml = "0.38.0"
 tempfile = "3.20.0"
 assert_cmd = "2.0.17"
+criterion = { version = "0.6", features = ["html_reports"] }
 
 # Profile configuration to optimize dependencies even in debug builds
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ cargo test
 
 The tool is designed to handle large Apple Health exports efficiently, targeting a throughput of at least 700,000 records per second (~6 to 12 months worth of data per second) on an 8-core, hyperthreaded CPU with an ssd.
 
+## Benchmarking
+
+The repository includes a Criterion benchmark at `benches/flamegraph.rs`.
+Run it with the [`cargo flamegraph`](https://github.com/ferrous-systems/flamegraph) subcommand to produce a flamegraph:
+
+```bash
+cargo flamegraph --bench flamegraph
+```
+
+The generated `flamegraph.svg` will appear in `target/flamegraph/`.
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for more details.

--- a/benches/flamegraph.rs
+++ b/benches/flamegraph.rs
@@ -1,0 +1,24 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use gpt_os::apple_health::extractor::AppleHealthExtractor;
+use gpt_os::core::Engine;
+use gpt_os::sinks::csv_zip::CsvZipSink;
+use std::path::Path;
+use tempfile::NamedTempFile;
+
+fn bench_sample(c: &mut Criterion) {
+    c.bench_function("process_sample_export", |b| {
+        b.iter(|| {
+            let extractor = AppleHealthExtractor;
+            let sink = CsvZipSink;
+            let engine = Engine::new(extractor, sink);
+            let input = Path::new("tests/fixtures/sample_export.xml");
+            let output = NamedTempFile::new().expect("temp file");
+            engine
+                .run(input, output.path(), 1, 1, 1)
+                .expect("run engine");
+        });
+    });
+}
+
+criterion_group!(benches, bench_sample);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- add a Criterion benchmark that runs the ETL pipeline on sample data
- allow running the benchmark with `cargo flamegraph`
- document benchmark usage in README

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6873004d6c8c832f92627f0da2de8208