### PR TITLE
Fix extractor thread error logging

### DIFF
--- a/src/apple_health/extractor.rs
+++ b/src/apple_health/extractor.rs
@@ -5,6 +5,7 @@ use crate::apple_health::types::GenericRecord;
 use crate::core::Extractor;
 use crate::error::Result;
 use crossbeam_channel as channel;
+use log::error;
 use rayon::ThreadPool;
 use std::{path::Path, sync::Arc, thread};
 
@@ -40,9 +41,8 @@ impl Extractor<GenericRecord> for AppleHealthExtractor {
 
             drop(sender);
 
-            if let Err(_) = result {
-                // Error occurred, but we can't send it through the channel
-                // The receiver will detect the channel is closed
+            if let Err(e) = result {
+                error!("Extractor thread failed: {}", e);
             }
         });
 


### PR DESCRIPTION
## Summary
- log extractor errors instead of ignoring them

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6873008dbebc832faa6fb75effee3926