### PR TITLE
Convert pipeline to async tokio runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,15 @@ clap = { version = "4.5.40", features = ["derive"] }
 log = "0.4"
 env_logger = "0.11.8"
 tempfile = "3.20.0"
+tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread", "fs", "sync"] }
+async-trait = "0.1"
 
 [dev-dependencies]
 quick-xml = "0.38.0"
 tempfile = "3.20.0"
 assert_cmd = "2.0.17"
 criterion = { version = "0.6", features = ["html_reports"] }
+tokio-test = "0.4"
 
 # Profile configuration to optimize dependencies even in debug builds
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Written in Rust, the project aims to provide a framework for transforming variou
 
 ## Features
 
-- Multithreaded XML parsing using `quick-xml` and `Rayon` for optimal performance.
+- Asynchronous XML parsing using `quick-xml` running on the Tokio runtime.
 - Memory-efficient processing with streaming and chunked buffering.
-- Dedicated Rayon thread pools for each phase are preloaded at startup to avoid latency.
+- Built on Tokio's multi-threaded runtime for efficient concurrency.
 - Outputs structured CSV files for various health record types, all compressed into a single ZIP archive.
 - Robust error handling and logging capabilities.
 - Cross-platform compatibility (Linux, macOS, Windows).
@@ -37,9 +37,6 @@ gpt-os [OPTIONS] <INPUT_FILE> <OUTPUT_ZIP>
 ### Options
 
 - `-v, --verbose`: Enable verbose logging.
-- `--extract-threads <N>`: Threads for extraction phase (default: available/2 + 1).
-- `--transform-threads <N>`: Threads for transformation phase (default: available/2 + 1).
-- `--load-threads <N>`: Threads for load phase (default: available/2 + 1).
 - `--no-metrics`: Disable printing of end-of-run metrics.
 - `-h, --help`: Show usage information.
 

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -39,7 +39,7 @@ The project is built around a generic transformation engine defined in `src/core
 
 The command-line interface in `src/main.rs` wires these pieces together using `Config` from `src/config.rs`. Logging and error handling are provided by `env_logger` and the custom `error` module.
 
-Parallelism is handled using dedicated Rayon thread pools for each phase of the ETL pipeline. These pools are preloaded before processing begins. The number of threads for extraction, transformation and loading can be configured via CLI options, with sensible defaults based on the available hardware.
+Concurrency is managed by the Tokio async runtime. CPU intensive work is executed using blocking tasks when necessary.
 
 ```
 Flow: Extractor -> Engine -> Sink

--- a/src/apple_health/extractor.rs
+++ b/src/apple_health/extractor.rs
@@ -4,49 +4,52 @@ use quick_xml::events::BytesStart;
 use crate::apple_health::types::GenericRecord;
 use crate::core::Extractor;
 use crate::error::Result;
+use async_trait::async_trait;
 use crossbeam_channel as channel;
 use log::error;
-use rayon::ThreadPool;
-use std::{path::Path, sync::Arc, thread};
+use std::path::Path;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio::task;
 
 pub struct AppleHealthExtractor;
 
+#[async_trait]
 impl Extractor<GenericRecord> for AppleHealthExtractor {
-    fn extract(
-        &self,
-        input_path: &Path,
-        pool: Arc<ThreadPool>,
-    ) -> Result<channel::Receiver<GenericRecord>> {
-        let (sender, receiver) = channel::unbounded();
-        let input_path = input_path.to_owned();
+    async fn extract(&self, input_path: &Path) -> Result<mpsc::Receiver<GenericRecord>> {
+        let (tx, rx) = mpsc::channel(100);
+        let (cb_tx, cb_rx) = channel::unbounded();
+        let path = input_path.to_owned();
 
-        thread::spawn(move || {
-            let result: Result<()> = pool.install(|| {
-                if input_path.extension().and_then(|s| s.to_str()) == Some("zip") {
-                    let content = xml_utils::extract_xml_from_zip(&input_path)?;
+        task::spawn_blocking(move || {
+            let result: Result<()> = (|| {
+                if path.extension().and_then(|s| s.to_str()) == Some("zip") {
+                    let content = xml_utils::extract_xml_from_zip(&path)?;
                     xml_utils::process_memory_chunks(
                         &content,
-                        &sender,
+                        &cb_tx,
                         Arc::new(Self::parse_generic),
                     )?;
                 } else {
-                    xml_utils::process_xml_file_mmap(
-                        &input_path,
-                        &sender,
-                        Arc::new(Self::parse_generic),
-                    )?;
+                    xml_utils::process_xml_file_mmap(&path, &cb_tx, Arc::new(Self::parse_generic))?;
                 }
                 Ok(())
-            });
-
-            drop(sender);
-
+            })();
+            drop(cb_tx);
             if let Err(e) = result {
                 error!("Extractor thread failed: {}", e);
             }
         });
 
-        Ok(receiver)
+        tokio::spawn(async move {
+            for record in cb_rx {
+                if tx.send(record).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        Ok(rx)
     }
 }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -81,7 +81,7 @@ where
         let grouped_records = transformer::transform(receiver).await;
         let transform_duration = transform_start.elapsed();
 
-        let total_records: usize = grouped_records.iter().map(|(_, v)| v.len()).sum();
+        let total_records: usize = grouped_records.values().map(Vec::len).sum();
         let record_types = grouped_records.len();
         info!(
             "Transformation completed in {:.3}s: {} records grouped into {} types",

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,8 @@ use log::{LevelFilter, error, info};
 use std::path::Path;
 use std::process;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let start_time = std::time::Instant::now();
     let config = config::Config::parse();
 
@@ -35,19 +36,7 @@ fn main() {
     let input_path = Path::new(&config.input_file);
     let output_path = Path::new(&config.output_zip);
 
-    let avail = std::thread::available_parallelism().map_or(1, |p| p.get());
-    let default_threads = avail / 2 + 1;
-    let extract_threads = config.extract_threads.unwrap_or(default_threads);
-    let transform_threads = config.transform_threads.unwrap_or(default_threads);
-    let load_threads = config.load_threads.unwrap_or(default_threads);
-
-    if let Err(e) = engine.run(
-        input_path,
-        output_path,
-        extract_threads,
-        transform_threads,
-        load_threads,
-    ) {
+    if let Err(e) = engine.run(input_path, output_path).await {
         error!("❌ Application error: {}", e);
         process::exit(1);
     }

--- a/src/xml_utils.rs
+++ b/src/xml_utils.rs
@@ -14,6 +14,8 @@ use std::sync::{
 
 use crate::error::{AppError, Result};
 
+type ParseFn<T> = Arc<dyn Fn(&BytesStart) -> Option<T> + Send + Sync + 'static>;
+
 /// Target chunk size in bytes
 pub const CHUNK_SIZE: usize = 2 * 1024 * 1024;
 
@@ -120,11 +122,7 @@ pub fn process_chunk_slice<T>(
 }
 
 /// Process pre-split chunks and send parsed rows
-pub fn process_chunks<T>(
-    data: &[u8],
-    sender: &channel::Sender<T>,
-    parse_fn: Arc<dyn Fn(&BytesStart) -> Option<T> + Send + Sync + 'static>,
-) -> usize
+pub fn process_chunks<T>(data: &[u8], sender: &channel::Sender<T>, parse_fn: ParseFn<T>) -> usize
 where
     T: Send + 'static,
 {
@@ -157,7 +155,7 @@ where
 pub fn process_xml_file_mmap<T>(
     input_path: &Path,
     sender: &channel::Sender<T>,
-    parse_fn: Arc<dyn Fn(&BytesStart) -> Option<T> + Send + Sync + 'static>,
+    parse_fn: ParseFn<T>,
 ) -> Result<()>
 where
     T: Send + 'static,
@@ -173,7 +171,7 @@ where
 pub fn process_memory_chunks<T>(
     content: &[u8],
     sender: &channel::Sender<T>,
-    parse_fn: Arc<dyn Fn(&BytesStart) -> Option<T> + Send + Sync + 'static>,
+    parse_fn: ParseFn<T>,
 ) -> Result<()>
 where
     T: Send + 'static,

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 use tempfile::NamedTempFile;
+use tokio_test::block_on;
 use zip::ZipArchive;
 
 #[test]
@@ -165,11 +166,7 @@ fn csv_sink_sorts_records_by_date() {
     map.entry("Steps".to_string()).or_default().extend([r1, r2]);
 
     let tmp = NamedTempFile::new().unwrap();
-    let pool = rayon::ThreadPoolBuilder::new()
-        .num_threads(1)
-        .build()
-        .unwrap();
-    pool.install(|| CsvZipSink.load(map, tmp.path())).unwrap();
+    block_on(CsvZipSink.load(map, tmp.path())).unwrap();
 
     let file = File::open(tmp.path()).unwrap();
     let mut archive = ZipArchive::new(file).unwrap();


### PR DESCRIPTION
## Summary
- migrate Extractor/Sink traits and Engine to async using tokio
- bridge AppleHealth extractor to async channel
- run CSV sink in blocking task
- adjust CLI and docs for new async runtime
- update tests to use tokio

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68732bc88184832faf69b045d83e6694