### PR TITLE
Fix flamegraph bench compile

### DIFF
--- a/benches/flamegraph.rs
+++ b/benches/flamegraph.rs
@@ -4,8 +4,10 @@ use gpt_os::core::Engine;
 use gpt_os::sinks::csv_zip::CsvZipSink;
 use std::path::Path;
 use tempfile::NamedTempFile;
+use tokio::runtime::Runtime;
 
 fn bench_sample(c: &mut Criterion) {
+    let rt = Runtime::new().expect("runtime");
     c.bench_function("process_sample_export", |b| {
         b.iter(|| {
             let extractor = AppleHealthExtractor;
@@ -13,9 +15,9 @@ fn bench_sample(c: &mut Criterion) {
             let engine = Engine::new(extractor, sink);
             let input = Path::new("tests/fixtures/sample_export.xml");
             let output = NamedTempFile::new().expect("temp file");
-            engine
-                .run(input, output.path(), 1, 1, 1)
-                .expect("run engine");
+            rt.block_on(async {
+                engine.run(input, output.path()).await.expect("run engine");
+            });
         });
     });
 }


### PR DESCRIPTION
## Summary
- update flamegraph benchmark for new `Engine::run` signature
- block on async run using a `tokio` runtime

## Testing
- `cargo check`
- `cargo check --benches`
- `cargo bench --no-run`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68743aaa4f94832f955788e1a1e0452f