### PR TITLE
Switch zip compression to zstd

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Written in Rust, the project aims to provide a framework for transforming variou
 - Asynchronous XML parsing using `quick-xml` running on the Tokio runtime.
 - Memory-efficient processing with streaming and chunked buffering.
 - Built on Tokio's multi-threaded runtime for efficient concurrency.
-- Outputs structured CSV files for various health record types, all compressed into a single ZIP archive.
+- Outputs structured CSV files for various health record types, all compressed using Zstandard into a single ZIP archive.
 - Robust error handling and logging capabilities.
 - Cross-platform compatibility (Linux, macOS, Windows).
 

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -35,7 +35,7 @@ The project is built around a generic transformation engine defined in `src/core
 
 - **Extractor**: `apple_health::extractor::AppleHealthExtractor` reads zipped or plain XML exports and streams `GenericRecord` values.
 - **Processable types**: Defined in `apple_health::types`, these models represent the XML elements found in the export.
-- **Sink**: `sinks::csv_zip::CsvZipSink` groups the records and writes them to compressed CSV files inside a ZIP archive.
+- **Sink**: `sinks::csv_zip::CsvZipSink` groups the records and writes them to Zstandard-compressed CSV files inside a ZIP archive.
 
 The command-line interface in `src/main.rs` wires these pieces together using `Config` from `src/config.rs`. Logging and error handling are provided by `env_logger` and the custom `error` module.
 

--- a/src/sinks/csv_zip.rs
+++ b/src/sinks/csv_zip.rs
@@ -136,7 +136,7 @@ where
     {
         let mut mini = ZipWriter::new(&mut cursor);
         let opts = FileOptions::<()>::default()
-            .compression_method(CompressionMethod::Deflated)
+            .compression_method(CompressionMethod::Zstd)
             .unix_permissions(0o644);
         mini.start_file(format!("{}.csv", name), opts)?;
         mini.write_all(&buf)?;


### PR DESCRIPTION
## Summary
- compress CSV mini-zips using `CompressionMethod::Zstd`
- update docs to mention Zstandard compression

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687518d08ed8832f9a411f01b16af6f0