### PR TITLE
Borrow sort keys to avoid allocation

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -11,7 +11,7 @@ This document provides essential information about the `gpt-os` repository to en
 The application follows a classic ETL pattern orchestrated by the `Engine` in `src/core.rs`.
 
 -   **`Extractor<T>` trait**: Responsible for reading data from a source (e.g., a file) and streaming it as `Processable` records. The primary implementation is `AppleHealthExtractor`.
--   **`Processable` trait**: Represents a single data record. It requires a `grouping_key()` (e.g., "HeartRate", "Steps") which the engine uses to group records. It can also have an optional `sort_key()`.
+-   **`Processable` trait**: Represents a single data record. It requires a `grouping_key()` (e.g., "HeartRate", "Steps") which the engine uses to group records. It can also have an optional `sort_key()` that returns a borrowed string for ordering within groups.
 -   **`Engine`**: The core orchestrator. It takes an `Extractor` and a `Sink`, receives the stream of records from the extractor, groups them by the `grouping_key` in a concurrent map, and then passes the grouped data to the `Sink`.
 -   **`Sink<T>` trait**: Responsible for loading the grouped records into a destination. The primary implementation is `CsvZipSink`, which writes data into compressed CSV files within a ZIP archive.
 

--- a/src/apple_health/types.rs
+++ b/src/apple_health/types.rs
@@ -61,7 +61,7 @@ impl Processable for GenericRecord {
         self.element_name.clone()
     }
 
-    fn sort_key(&self) -> Option<String> {
+    fn sort_key(&self) -> Option<&str> {
         let keys = [
             "startDate",
             "date",
@@ -73,7 +73,7 @@ impl Processable for GenericRecord {
         ];
         for k in keys {
             if let Some(v) = self.attributes.get(k) {
-                return Some(v.clone());
+                return Some(v.as_str());
             }
         }
         None

--- a/src/core.rs
+++ b/src/core.rs
@@ -13,7 +13,7 @@ pub trait Processable: Send + Sync + Debug + 'static {
     fn grouping_key(&self) -> String;
 
     /// Optional key used for ordering records within groups.
-    fn sort_key(&self) -> Option<String> {
+    fn sort_key(&self) -> Option<&str> {
         None
     }
 }

--- a/src/sinks/csv_zip.rs
+++ b/src/sinks/csv_zip.rs
@@ -122,7 +122,7 @@ where
 {
     use std::collections::BTreeSet;
 
-    recs.sort_by_key(|r| r.sort_key().unwrap_or_default());
+    recs.sort_by(|a, b| a.sort_key().unwrap_or("").cmp(b.sort_key().unwrap_or("")));
 
     // build CSV in memory
     let mut buf = Vec::with_capacity(recs.len() * 100);

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -131,6 +131,9 @@ fn csv_sink_sorts_records_by_date() {
     let r1 = parse(xml1);
     let r2 = parse(xml2);
 
+    assert_eq!(r1.sort_key(), Some("2023-01-02T00:00:00Z"));
+    assert_eq!(r2.sort_key(), Some("2023-01-01T00:00:00Z"));
+
     let mut map: HashMap<String, Vec<GenericRecord>> = HashMap::new();
     map.entry("Steps".to_string()).or_default().extend([r1, r2]);
 


### PR DESCRIPTION
## Summary
- Borrow sort keys in Processable and GenericRecord to avoid cloning
- Sort CSV records using borrowed comparator instead of caching string keys
- Extend unit test to assert sort key usage

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b5a48e8a0c832f83581cdd2bddbd6b