### PR TITLE
Streamline CSV header handling

### DIFF
--- a/src/apple_health/types.rs
+++ b/src/apple_health/types.rs
@@ -40,20 +40,18 @@ impl GenericRecord {
 }
 
 impl CsvWritable for GenericRecord {
-    fn headers(&self) -> Vec<String> {
-        let mut keys: Vec<String> = self.attributes.keys().cloned().collect();
-        keys.sort();
-        keys
+    fn header_keys(&self) -> impl Iterator<Item = &str> {
+        self.attributes.keys().map(String::as_str)
     }
 
     fn write<W: std::io::Write>(
         &self,
         writer: &mut csv::Writer<W>,
-        headers: &[String],
+        headers: &[&str],
     ) -> csv::Result<()> {
         let record: Vec<&str> = headers
             .iter()
-            .map(|h| self.attributes.get(h).map(String::as_str).unwrap_or(""))
+            .map(|h| self.attributes.get(*h).map(String::as_str).unwrap_or(""))
             .collect();
         writer.write_record(&record)
     }

--- a/src/sinks/csv_zip.rs
+++ b/src/sinks/csv_zip.rs
@@ -16,10 +16,10 @@ use zip::{CompressionMethod, ZipWriter, write::FileOptions};
 /// Trait for writing records to a CSV writer using dynamic headers.
 pub trait CsvWritable {
     /// Return the attribute keys used for CSV headers.
-    fn headers(&self) -> Vec<String>;
+    fn header_keys(&self) -> impl Iterator<Item = &str>;
 
     /// Write the record using the provided header ordering.
-    fn write<W: Write>(&self, writer: &mut csv::Writer<W>, headers: &[String]) -> csv::Result<()>;
+    fn write<W: Write>(&self, writer: &mut csv::Writer<W>, headers: &[&str]) -> csv::Result<()>;
 }
 
 pub struct CsvZipSink;
@@ -131,11 +131,11 @@ where
     // build CSV in memory
     let mut buf = Vec::with_capacity(recs.len() * 100);
     {
-        let mut header_set = BTreeSet::new();
+        let mut header_set: BTreeSet<&str> = BTreeSet::new();
         for r in &*recs {
-            header_set.extend(r.headers());
+            header_set.extend(r.header_keys());
         }
-        let headers: Vec<String> = header_set.into_iter().collect();
+        let headers: Vec<&str> = header_set.into_iter().collect();
 
         let mut w = csv::WriterBuilder::new()
             .has_headers(true)


### PR DESCRIPTION
## Summary
- expose header keys as iterators in `CsvWritable` and use `&str` slices in writers
- build CSV headers once via `BTreeSet<&str>` during zip creation
- simplify `GenericRecord` header iteration without sorting or cloning

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b1184000832f942dd6f22851d9a5