### PR TITLE
docs: clarify ZIP compression method

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Written in Rust, the project aims to provide a framework for transforming variou
 - Asynchronous XML parsing using `quick-xml` running on the Tokio runtime.
 - Memory-efficient processing with streaming and chunked buffering.
 - Built on Tokio's multi-threaded runtime for efficient concurrency.
-- Outputs structured CSV files for various health record types, all compressed using Zstandard into a single ZIP archive.
+- Outputs structured CSV files for various health record types, compressed using ZIP's Deflate (level 2) into a single archive. Configurable compression is planned for future releases.
 - Robust error handling and logging capabilities.
 - Cross-platform compatibility (Linux, macOS, Windows).
 

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -35,7 +35,7 @@ The project is built around a generic transformation engine defined in `src/core
 
 - **Extractor**: `apple_health::extractor::AppleHealthExtractor` reads zipped or plain XML exports and streams `GenericRecord` values.
 - **Processable types**: Defined in `apple_health::types`, these models represent the XML elements found in the export.
-- **Sink**: `sinks::csv_zip::CsvZipSink` groups the records and writes them to Zstandard-compressed CSV files inside a ZIP archive.
+- **Sink**: `sinks::csv_zip::CsvZipSink` groups the records and writes them to CSV files compressed with ZIP's Deflate (level 2) inside a ZIP archive. Future versions may allow the compression method to be configured.
 
 The command-line interface in `src/main.rs` wires these pieces together using `Config` from `src/config.rs`. Logging and error handling are provided by `env_logger` and the custom `error` module.
 


### PR DESCRIPTION
## Summary
- clarify that CSV outputs are Deflate-compressed in the final ZIP archive
- document future plans for configurable compression

## Testing
- `cargo fmt`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b1541114832f9ebff0cf5c727850