### PR TITLE
Optimize Apple Health parsing throughput

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ zip = "4.6.0"
 crossbeam-channel = "0.5.15"
 memmap2 = "0.9.8"
 thiserror = "2.0.16"
+ahash = "0.8.11"
 clap = { version = "4.5.46", features = ["derive"] }
 log = "0.4.27"
 env_logger = "0.11.8"


### PR DESCRIPTION
## Summary
- replace generic record attribute storage with `ahash::AHashMap` and remove intermediate allocations during XML attribute parsing
- stream parsed batches directly to the output channel and enlarge the XML reader buffer to cut per-record overhead

## Testing
- cargo fmt
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d15f8f8894832f9bfaa8da453351d6